### PR TITLE
Update version numbers for TensorFlow 9.98.0-rc0

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -18,13 +18,13 @@ limitations under the License.
 
 // TensorFlow uses semantic versioning, see http://semver.org/.
 
-#define TF_MAJOR_VERSION 1
-#define TF_MINOR_VERSION 11
+#define TF_MAJOR_VERSION 9
+#define TF_MINOR_VERSION 98
 #define TF_PATCH_VERSION 0
 
 // TF_VERSION_SUFFIX is non-empty for pre-releases (e.g. "-alpha", "-alpha.1",
 // "-beta", "-rc", "-rc.1")
-#define TF_VERSION_SUFFIX "-rc1"
+#define TF_VERSION_SUFFIX "-rc0"
 
 #define TF_STR_HELPER(x) #x
 #define TF_STR(x) TF_STR_HELPER(x)

--- a/tensorflow/tools/docker/Dockerfile.devel
+++ b/tensorflow/tools/docker/Dockerfile.devel
@@ -78,7 +78,7 @@ RUN mkdir /bazel && \
 
 # Download and build TensorFlow.
 WORKDIR /tensorflow
-RUN git clone --branch=r1.11 --depth=1 https://github.com/tensorflow/tensorflow.git .
+RUN git clone --branch=r9.98 --depth=1 https://github.com/tensorflow/tensorflow.git .
 
 # TODO(craigcitro): Don't install the pip package, since it makes it
 # more difficult to experiment with local changes. Instead, just add

--- a/tensorflow/tools/docker/Dockerfile.devel-gpu
+++ b/tensorflow/tools/docker/Dockerfile.devel-gpu
@@ -100,7 +100,7 @@ RUN mkdir /bazel && \
 
 # Download and build TensorFlow.
 WORKDIR /tensorflow
-RUN git clone --branch=r1.11 --depth=1 https://github.com/tensorflow/tensorflow.git .
+RUN git clone --branch=r9.98 --depth=1 https://github.com/tensorflow/tensorflow.git .
 
 # Configure the build for our CUDA configuration.
 ENV CI_BUILD_PYTHON python

--- a/tensorflow/tools/docker/Dockerfile.devel-mkl
+++ b/tensorflow/tools/docker/Dockerfile.devel-mkl
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 LABEL maintainer="Clayne Robison <clayne.b.robison@intel.com>"
 
 # These parameters can be overridden by parameterized_docker_build.sh
-ARG TF_BUILD_VERSION=r1.11
+ARG TF_BUILD_VERSION=r9.98
 ARG PYTHON="python"
 ARG PYTHON3_DEV=""
 ARG WHL_DIR="/tmp/pip"

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,7 +45,7 @@ DOCLINES = __doc__.split('\n')
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
-_VERSION = '1.11.0-rc1'
+_VERSION = '9.98.0-rc0'
 
 REQUIRED_PACKAGES = [
     'absl-py >= 0.1.6',


### PR DESCRIPTION
Before merging this PR, please double check that it has correctly updated
`core/public/version.h` and `tools/pip_package/setup.py`. Also review the
notes below:

```
Detected Major.Minor change.
Updating pattern r1.11 to r9.98 in additional files
Major: 1 -> 9
Minor: 11 -> 98
Patch: 0 -> 0

WARNING: Below are potentially instances of lingering old version string 
"1.11.0-rc1" in source directory "tensorflow/" that are not updated by this 
script. Please check them manually!
tensorflow/java/maven/proto/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/libtensorflow_jni/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/tensorflow-hadoop/pom.xml:8:1.11.0-rc1
tensorflow/java/maven/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/spark-tensorflow-connector/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/libtensorflow/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/libtensorflow_jni_gpu/pom.xml:9:1.11.0-rc1
tensorflow/java/maven/tensorflow/pom.xml:9:1.11.0-rc1

No lingering old version strings "1.11.0rc1" found in source directory 
"tensorflow/". Good.
No lingering old version strings "r1.11" found in source directory 
"tensorflow/". Good.
```